### PR TITLE
Improve Argon2 documentation and workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+Version v0.2.35 (4/4/2016)
+==========================
+
+* Improve cross compiling from GCC to msvc.
+* Fix BCrypt algorithm when using a cost of 31.
+* Improve building on OpenBSD.
+* Add implementation of SHA3 digest function.
+* Fix errors in Blake2b that could lead to incorrect output. The Blake2b
+  initialization functions are modified to take parameters by value instead of
+  by reference, which may break users of the interfaces.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-crypto"
-version = "0.2.34"
+version = "0.2.35"
 authors = ["The Rust-Crypto Project Developers"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/DaGenix/rust-crypto/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ time = "^0.1"
 rand = "^0.3"
 rustc-serialize = "^0.3"
 
+

--- a/build.rs
+++ b/build.rs
@@ -25,10 +25,15 @@ fn main() {
         let mut cfg = gcc::Config::new();
         cfg.file("src/util_helpers.c");
         cfg.file("src/aesni_helpers.c");
-        // gcc can't build this library so, unless the user has explicitly
-        // specified a different C compiler, use clang.
         if env::var_os("CC").is_none() {
-            cfg.compiler(Path::new("clang"));
+            if host.contains("openbsd") {
+                // Use clang on openbsd since there have been reports that
+                // GCC doesn't like some of the assembly that we use on that
+                // platform.
+                cfg.compiler(Path::new("clang"));
+            } else {
+                cfg.compiler(Path::new("cc"));
+            }
         }
         cfg.compile("lib_rust_crypto_helpers.a");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+
 #![cfg_attr(feature = "with-bench", feature(test))]
 
 extern crate rand;

--- a/src/scrypt.rs
+++ b/src/scrypt.rs
@@ -261,7 +261,7 @@ pub fn scrypt(password: &[u8], salt: &[u8], params: &ScryptParams, output: &mut 
  * and p parameters are encoded using 4 bytes (format 1) is used. Both formats use a 128-bit salt
  * and a 256-bit hash. The format is indicated as "rscrypt" which is short for "Rust Scrypt format."
  *
- * $rscrypt$<format>$<base64(log_n,r,p)>$<base64(salt)>$<based64(hash)>$
+ * $rscrypt$<format>$<base64(log_n,r,p)>$<base64(salt)>$<base64(hash)>$
  *
  * # Arguments
  *


### PR DESCRIPTION
Story: I was working on doing just this before I found your original [PR#347](https://github.com/DaGenix/rust-crypto/pull/347). I had written a lot of tests and documentation and I transferred it over. 

I also wrapped a lot of the original work into builders to allow for reuse when using the library. I could repeat what in the documentation, but it's likely easier to just check that out.

The simple patterns are largely the same:  

``` rust
use crypto::argon2::simple2i;

use rustc_serialize::hex::ToHex; // for simple serialization

const EXPECTED: &'static str = concat!("d92f206d6220bd3f491809fb1ad9e54c9be2f13545b3fd3a9cfc7fbcc5f596dd", 
                                        "b744ff23406d09c8c1a30cb6a1c5552a8197f0d15d93c8acceda0cfe46bb66a9");

// Compute a 64-byte Argon2i hash of "princess" with "super salt"
let hash = simple2i("princess", "super salt");
assert_eq!(hash.to_hex(), EXPECTED);
```

For more complex usage: 

``` rust
use rustc_serialize::hex::ToHex; // for nice hashes
use crypto::argon2::{ Algorithm, a2hash };

// Expected hash
const HASH: &'static str = concat!("024d11660b08a1c38dbb2c048f48cbda",
                                   "c76a22547367a0f17fc32a63232c6dd7");

// Set 4 lanes, 4 passes, and 350MB memory
let alg = Algorithm::argon2d()
                .hash_length(32)                // 32 bytes of hash
                .lanes(4)                       // 4 threads  
                .passes(4)                      // 4 passes
                .memory_size(350 * 1024);       // 350 * 1024 == 350MB

let mut buff = vec![0u8; 32]; // 32 bytes
alg.build().unwrap()
    .password("welcome")                    // Password
    .salt("More Salt!")                     // Salt
    .assoc_data(&[34, 32, 19, 09, 0xff])    // Associated data, `x`
    .secret(&[03, 43, 32])                  // Secret, `k`! don't tell anyone!
    .hash_inplace(buff.as_mut_slice())      // hash into the buffer we alloc'd before
    .unwrap();                              // Alternately, could have used .hash() which 
                                            //      returns a `Result<Vec<u8>, ParamErr>`

// Make sure they're equal
assert_eq!(buff.to_hex(), HASH);
```

Both of these examples are directly in the documentation!

E: Link to [documentation ](http://nava2.github.io/rust-crypto/crypto/argon2/index.html).
